### PR TITLE
currency formatter

### DIFF
--- a/components/form.vue
+++ b/components/form.vue
@@ -37,7 +37,7 @@ export default {
     computed: {
         getValue() {
             return `${
-                this.$store.getters.getTotalSpending
+                this.$store.getters.getTotalSpending.toLocaleString({style: 'currency'})
             }$! That is a lot of money!`;
         }
     },


### PR DESCRIPTION
prevents ugly numbers like 
```
24.583333333333332$! That is a lot of money!
```